### PR TITLE
Modernisation for Laravel 12+ and PHP 8.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ emSzmal Banking API wrapper in PHP
 
 Check full documentation here: [opensource.duma.sh/libraries/php/emszmal](https://opensource.duma.sh/libraries/php/emszmal)
 
+## Requirements
+
+- PHP `^8.3`
+- Laravel `^12.0 || ^13.0`
+
 ## Install
 
 Via Composer

--- a/README.md
+++ b/README.md
@@ -1,202 +1,47 @@
-# emSzmal Banking API wrapper in PHP
+# emSzmal Banking API Wrapper
 
-[![Latest Version on Packagist][ico-version]][link-packagist]
-[![Software License][ico-license]](LICENSE.md)
-[![Total Downloads][ico-downloads]][link-downloads]
+PHP wrapper for the [emSzmal](https://emszmal.pl) banking API — enables fetching account data and transaction history from Polish banks.
 
-emSzmal Banking API wrapper in PHP
-
-Check full documentation here: [opensource.duma.sh/libraries/php/emszmal](https://opensource.duma.sh/libraries/php/emszmal)
+Full documentation: [opensource.duma.sh/libraries/php/emszmal](https://opensource.duma.sh/libraries/php/emszmal)
 
 ## Requirements
 
 - PHP `^8.3`
-- Laravel `^12.0 || ^13.0`
+- Laravel `^12.0 || ^13.0` (optional — also works as plain PHP)
 
-## Install
+## Installation
 
-Via Composer
-
-``` bash
-$ composer require kduma/emszmal-api
+```bash
+composer require kduma/emszmal-api
 ```
 
 ## Usage
 
 ```php
 $api = new \KDuma\emSzmalAPI\emSzmalAPI(
-    api_id: $api_id, 
+    api_id: $api_id,
     api_key: $api_key,
-    timeout: 120,
     cache_provider: new \KDuma\emSzmalAPI\CacheProviders\NoCacheProvider(),
 );
 
 $session = $api->SayHello();
 
-$BankCredentials = new \KDuma\emSzmalAPI\DTO\BankCredentials(
-    provider: \KDuma\emSzmalAPI\Enums\Bank::PKOiPKO, 
-    login: 'Login', 
-    password: 'Password',
-    user_context: '',
-    token_value: '',
-);
-
 $accounts = $api->GetAccountsList(
     session: $session,
-    credentials: $BankCredentials,
+    credentials: new \KDuma\emSzmalAPI\DTO\BankCredentials(
+        provider: \KDuma\emSzmalAPI\Enums\Bank::PKOiPKO,
+        login: 'login',
+        password: 'password',
+        user_context: '',
+        token_value: '',
+    ),
 );
 
-$transactions = $api->GetAccountHistory(
-    session: $session,
-    account_number: "account number", 
-    date_since: '2016-10-25', 
-    date_to: '2016-10-30', 
-    credentials: $BankCredentials,
-);
-
-$api->SayBye(
-    session: $session,
-);
+$api->SayBye(session: $session);
 ```
 
-## Laravel Usage
-
-### Setup
-
-Add following entries to your `.env` file:
-
-	EMSZMAL_API_ID="<api id>"
-	EMSZMAL_API_KEY=<api key>
-
-	EMSZMAL_BANK_PROVIDER_ID=<provider ID>
-	EMSZMAL_BANK_LOGIN=<login>
-	EMSZMAL_BANK_PASSWORD=<password>
-    EMSZMAL_BANK_USER_TOKEN=<token from bank>
-    
-### Usage
-You can resolve `emSzmalAPI::class` class:
+In Laravel, you can resolve the client from the container after adding credentials to `.env`:
 
 ```php
 $api = app(\KDuma\emSzmalAPI\emSzmalAPI::class);
-
-$session = $api->SayHello();
-
-$accounts = $api->GetAccountsList(
-    session: $session,
-);
-
-$transactions = $api->GetAccountHistory(
-    session: $session,
-    account_number: 'account number', 
-    date_since: '2016-10-25', 
-    date_to: '2016-10-30',
-);
-
-$api->SayBye(
-    session: $session,
-);
 ```
-
-or You can use injection container
-
-```php
-Route::get('/api', function (\KDuma\emSzmalAPI\emSzmalAPI $api) {
-    $session = $api->SayHello();
-
-    $accounts = $api->GetAccountsList(
-        session: $session,
-    );
-    
-    $transactions = $api->GetAccountHistory(
-        session: $session,
-        account_number: 'account number', 
-        date_since: '2016-10-25', 
-        date_to: '2016-10-30',
-    );
-
-    $api->SayBye(
-        session: $session,
-    );
-});
-```
-    
-### Multiple Bank Credentials
-
-You can use multiple bank credentials. First, run the following command to copy config file:
-
-    php artisan vendor:publish --provider="KDuma\emSzmalAPI\Laravel\ServiceProvider"
-
-In Your `config/emszmalapi.php` file, in `bank_credentials` section add additional credentials:
-
-```php
-'bank_credentials' => [
-    'bank_1' => [
-        'provider' => env('EMSZMAL_BANK_1_PROVIDER_ID'),
-        'login' => env('EMSZMAL_BANK_1_LOGIN'),
-        'password' => env('EMSZMAL_BANK_1_PASSWORD'),
-        'user_context' => env('EMSZMAL_BANK_1_USER_CONTEXT', "I"),
-        'token_value' => env('EMSZMAL_BANK_1_USER_TOKEN', ''),
-    ],
-    'bank_2' => [
-        'provider' => env('EMSZMAL_BANK_2_PROVIDER_ID'),
-        'login' => env('EMSZMAL_BANK_2_LOGIN'),
-        'password' => env('EMSZMAL_BANK_2_PASSWORD'),
-        'user_context' => env('EMSZMAL_BANK_2_USER_CONTEXT', "I"),
-        'token_value' => env('EMSZMAL_BANK_2_USER_TOKEN', ''),
-    ],
-],
-```
-Now you can use the alias when calling API methods:
-```php
-$api = app(\KDuma\emSzmalAPI\emSzmalAPI::class);
-
-$session = $api->SayHello();
-
-$bank_1_accounts = $api->GetAccountsList(
-    session: $session,
-    credentials: 'bank_1',
-);
-$bank_1_transactions = $api->GetAccountHistory(
-    session: $session,
-    account_number: "account number", 
-    date_since: '2016-10-25', 
-    date_to: '2016-10-30', 
-    credentials: 'bank_1',
-);
-
-
-$bank_2_accounts = $api->GetAccountsList(
-    session: $session,
-    credentials: 'bank_2',
-);
-
-$bank_2_transactions = $api->GetAccountHistory(
-    session: $session,
-    account_number: "account number", 
-    date_since: '2016-10-25', 
-    date_to: '2016-10-30', 
-    credentials: 'bank_2',
-);
-
-$api->SayBye(
-    session: $session,
-);
-```
-
-## Credits
-
-- [Krystian Duma][link-author]
-- [All Contributors][link-contributors]
-
-## License
-
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
-
-[ico-version]: https://img.shields.io/packagist/v/kduma/emszmal-api.svg?style=flat-square
-[ico-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square
-[ico-downloads]: https://img.shields.io/packagist/dt/kduma/emszmal-api.svg?style=flat-square
-
-[link-packagist]: https://packagist.org/packages/kduma/emszmal-api
-[link-downloads]: https://packagist.org/packages/kduma/emszmal-api
-[link-author]: https://github.com/kduma
-[link-contributors]: ../../contributors

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # emSzmal Banking API Wrapper
 
+[![Latest Stable Version](https://poser.pugx.org/kduma/emszmal-api/v/stable.svg)](https://packagist.org/packages/kduma/emszmal-api)
+[![Total Downloads](https://poser.pugx.org/kduma/emszmal-api/downloads.svg)](https://packagist.org/packages/kduma/emszmal-api)
+[![License](https://poser.pugx.org/kduma/emszmal-api/license.svg)](https://packagist.org/packages/kduma/emszmal-api)
+
 PHP wrapper for the [emSzmal](https://emszmal.pl) banking API — enables fetching account data and transaction history from Polish banks.
 
 Full documentation: [opensource.duma.sh/libraries/php/emszmal](https://opensource.duma.sh/libraries/php/emszmal)

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,12 @@
     ],
     "require": {
         "php": "^8.3",
-        "guzzlehttp/guzzle": "^7.0",
-        "illuminate/support": "^12.0 || ^13.0",
-        "illuminate/cache": "^12.0 || ^13.0"
+        "ext-json": "*",
+        "guzzlehttp/guzzle": "^7.0"
+    },
+    "suggest": {
+        "illuminate/support": "Required for Laravel integration (ServiceProvider, config())",
+        "illuminate/cache": "Required for Laravel cache provider integration"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,10 @@
         }
     ],
     "require": {
-        "php": "~8.1",
+        "php": "^8.3",
         "guzzlehttp/guzzle": "^7.0",
-        "ext-json": "*"
+        "illuminate/support": "^12.0 || ^13.0",
+        "illuminate/cache": "^12.0 || ^13.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CacheProviders/ArrayCacheProvider.php
+++ b/src/CacheProviders/ArrayCacheProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\CacheProviders;
 
 class ArrayCacheProvider implements CacheProviderInterface

--- a/src/CacheProviders/CacheProviderInterface.php
+++ b/src/CacheProviders/CacheProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\CacheProviders;
 
 interface CacheProviderInterface

--- a/src/CacheProviders/LaravelCacheProvider.php
+++ b/src/CacheProviders/LaravelCacheProvider.php
@@ -17,9 +17,13 @@ class LaravelCacheProvider implements CacheProviderInterface
     public function cache(string $key, callable $callable): mixed
     {
         if ($this->remember_for) {
-            return $this->cache_manager->remember($key, Carbon::now()->addMinutes($this->remember_for), $callable);
-        } else {
-            return $this->cache_manager->rememberForever($key, $callable);
+            return $this->cache_manager->remember(
+                $key,
+                Carbon::now()->addMinutes($this->remember_for),
+                $callable
+            );
         }
+
+        return $this->cache_manager->rememberForever($key, $callable);
     }
 }

--- a/src/CacheProviders/LaravelCacheProvider.php
+++ b/src/CacheProviders/LaravelCacheProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\CacheProviders;
 
 use Illuminate\Cache\CacheManager;

--- a/src/CacheProviders/NoCacheProvider.php
+++ b/src/CacheProviders/NoCacheProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\CacheProviders;
 
 class NoCacheProvider implements CacheProviderInterface

--- a/src/DTO/Account.php
+++ b/src/DTO/Account.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\DTO;
 
 use KDuma\emSzmalAPI\Values\Money;

--- a/src/DTO/BankCredentials.php
+++ b/src/DTO/BankCredentials.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\DTO;
 
 use KDuma\emSzmalAPI\Enums\Bank;

--- a/src/DTO/BankCredentials.php
+++ b/src/DTO/BankCredentials.php
@@ -33,4 +33,5 @@ class BankCredentials
             ],
         ];
     }
+
 }

--- a/src/DTO/SecondPhaseAuthenticationData.php
+++ b/src/DTO/SecondPhaseAuthenticationData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\DTO;
 
 class SecondPhaseAuthenticationData

--- a/src/DTO/Session.php
+++ b/src/DTO/Session.php
@@ -19,8 +19,9 @@ class Session
 
     public function toCookieJar(): CookieJar
     {
-        return CookieJar::fromArray([
-            'SessionId' => $this->id,
-        ], 'web.emszmal.pl');
+        return CookieJar::fromArray(
+            ['SessionId' => $this->id],
+            'web.emszmal.pl'
+        );
     }
 }

--- a/src/DTO/Session.php
+++ b/src/DTO/Session.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\DTO;
 
 use GuzzleHttp\Cookie\CookieJar;

--- a/src/DTO/Transaction.php
+++ b/src/DTO/Transaction.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\DTO;
 
 use DateTimeImmutable;

--- a/src/Enums/Bank.php
+++ b/src/Enums/Bank.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\Enums;
 
 enum Bank: int

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -17,20 +17,20 @@ use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 class ServiceProvider extends LaravelServiceProvider implements DeferrableProvider
 {
     
-    public function boot()
+    public function boot(): void
     {
         $this->handleConfigs();
     }
-    
-    public function register()
+
+    public function register(): void
     {
-        $this->app->singleton(CacheProviderInterface::class, function (Application $app) {
+        $this->app->singleton(CacheProviderInterface::class, function (Application $app): CacheProviderInterface {
             return $app->make(LaravelCacheProvider::class, [
                 'remember_for' => config('emszmalapi.cache.remember_for'),
             ]);
         });
 
-        $this->app->singleton(emSzmalAPI::class, function (Application $app) {
+        $this->app->singleton(emSzmalAPI::class, function (Application $app): emSzmalAPI {
             $api = new emSzmalAPI(
                 api_id: config('emszmalapi.license.api_id'),
                 api_key: config('emszmalapi.license.api_key'),
@@ -56,12 +56,12 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
         });
     }
     
-    public function provides()
+    public function provides(): array
     {
         return [CacheProviderInterface::class, emSzmalAPI::class];
     }
 
-    private function handleConfigs()
+    private function handleConfigs(): void
     {
         $configPath = __DIR__.'/../../config/emszmalapi.php';
 

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\Laravel;
 
 use Exception;

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -8,14 +8,14 @@ use Exception;
 use KDuma\emSzmalAPI\emSzmalAPI;
 use KDuma\emSzmalAPI\DTO\BankCredentials;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Support\DeferrableProvider;
 use KDuma\emSzmalAPI\CacheProviders\LaravelCacheProvider;
 use KDuma\emSzmalAPI\CacheProviders\CacheProviderInterface;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 
 
-class ServiceProvider extends LaravelServiceProvider
+class ServiceProvider extends LaravelServiceProvider implements DeferrableProvider
 {
-    protected $defer = true;
     
     public function boot()
     {

--- a/src/Values/Money.php
+++ b/src/Values/Money.php
@@ -14,7 +14,7 @@ class Money
 
     public static function fromFloat(float $amount, int $decimals = 2): static
     {
-        return new static(round($amount * 10 ** $decimals), $decimals);
+        return new static((int) round($amount * (10 ** $decimals)), $decimals);
     }
 
     public function __toString(): string
@@ -24,6 +24,6 @@ class Money
 
     public function toFloat(): float
     {
-        return $this->amount / 10 ** $this->decimals;
+        return $this->amount / (10 ** $this->decimals);
     }
 }

--- a/src/Values/Money.php
+++ b/src/Values/Money.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI\Values;
 
 class Money

--- a/src/emSzmalAPI.php
+++ b/src/emSzmalAPI.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KDuma\emSzmalAPI;
 
 use DateTimeImmutable;

--- a/src/emSzmalAPI.php
+++ b/src/emSzmalAPI.php
@@ -25,10 +25,7 @@ class emSzmalAPI
     protected readonly Client $client;
     private ?string $session_id = null;
 
-    /**
-     * @var callable|null
-     */
-    protected $default_bank_credentials_resolver = null;
+    protected ?callable $default_bank_credentials_resolver = null;
 
     public function __construct(
         public readonly string $api_id,
@@ -66,7 +63,7 @@ class emSzmalAPI
     /**
      * @throws Exception|GuzzleException
      */
-    public function GetSecondPhaseAuthenticationData(Session $session, string|BankCredentials $credentials = null): SecondPhaseAuthenticationData
+    public function GetSecondPhaseAuthenticationData(Session $session, string|BankCredentials|null $credentials = null): SecondPhaseAuthenticationData
     {
         $credentials = $this->GetCredentials($credentials);
 
@@ -93,7 +90,7 @@ class emSzmalAPI
     /**
      * @throws Exception|GuzzleException
      */
-    public function DoSecondPhaseAuthentication(Session $session, string $AuthenticationCode, string|BankCredentials $credentials = null): void
+    public function DoSecondPhaseAuthentication(Session $session, string $AuthenticationCode, string|BankCredentials|null $credentials = null): void
     {
         $credentials = $this->GetCredentials($credentials);
 
@@ -114,7 +111,7 @@ class emSzmalAPI
      * @return Account[]
      * @throws Exception|GuzzleException
      */
-    public function GetAccountsList(Session $session, string|BankCredentials $credentials = null): array
+    public function GetAccountsList(Session $session, string|BankCredentials|null $credentials = null): array
     {
         $credentials = $this->GetCredentials($credentials);
 
@@ -154,10 +151,10 @@ class emSzmalAPI
      */
     public function GetAccountHistory(
         Session $session,
-        string $account_number, 
-        DateTimeImmutable|string $date_since, 
-        DateTimeImmutable|string $date_to, 
-        string|BankCredentials $credentials = null
+        string $account_number,
+        DateTimeImmutable|string $date_since,
+        DateTimeImmutable|string $date_to,
+        string|BankCredentials|null $credentials = null
     ): array
     {
         $credentials = $this->GetCredentials($credentials);
@@ -230,7 +227,7 @@ class emSzmalAPI
         return true;
     }
 
-    public function setDefaultBankCredentialsResolver(callable $default_bank_credentials_resolver = null): static
+    public function setDefaultBankCredentialsResolver(?callable $default_bank_credentials_resolver = null): static
     {
         $this->default_bank_credentials_resolver = $default_bank_credentials_resolver;
 
@@ -240,7 +237,7 @@ class emSzmalAPI
     /**
      * @throws Exception
      */
-    protected function GetCredentials(string|BankCredentials $credentials = null): BankCredentials
+    protected function GetCredentials(string|BankCredentials|null $credentials = null): BankCredentials
     {
         if ($credentials instanceof BankCredentials) {
             return $credentials;


### PR DESCRIPTION
## Summary
- Bump PHP requirement to `^8.3`
- Add `illuminate/support` and `illuminate/cache` `^12.0 || ^13.0`
- Replace deprecated `$defer = true` with `DeferrableProvider` interface
- Add `declare(strict_types=1)` to all source files
- Add full type hints to all classes and methods