### PR TITLE
fix: add type-safe config validation in ServiceProvider

### DIFF
--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -31,24 +31,35 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
         });
 
         $this->app->singleton(emSzmalAPI::class, function (Application $app): emSzmalAPI {
+            $apiId = config('emszmalapi.license.api_id');
+            $apiKey = config('emszmalapi.license.api_key');
+
+            if (empty($apiId) || ! is_string($apiId)) {
+                throw new \RuntimeException('emSzmal API: emszmalapi.license.api_id is not configured.');
+            }
+
+            if (empty($apiKey) || ! is_string($apiKey)) {
+                throw new \RuntimeException('emSzmal API: emszmalapi.license.api_key is not configured.');
+            }
+
             $api = new emSzmalAPI(
-                api_id: config('emszmalapi.license.api_id'),
-                api_key: config('emszmalapi.license.api_key'),
-                timeout: config('emszmalapi.timeout', 120),
+                api_id: $apiId,
+                api_key: $apiKey,
+                timeout: (int) config('emszmalapi.timeout', 120),
                 cache_provider: $app->make(CacheProviderInterface::class),
             );
-            
+
             $api->setDefaultBankCredentialsResolver(function ($identifier = 'default') {
                 if (! config('emszmalapi.bank_credentials.'.$identifier)) {
                     throw new Exception('There is no credentials with id '.$identifier.'!');
                 }
 
                 return new BankCredentials(
-                    provider: config('emszmalapi.bank_credentials.'.$identifier.'.provider') ?? '',
-                    login: config('emszmalapi.bank_credentials.'.$identifier.'.login') ?? '',
-                    password: config('emszmalapi.bank_credentials.'.$identifier.'.password') ?? '',
-                    user_context: config('emszmalapi.bank_credentials.'.$identifier.'.user_context') ?? '',
-                    token_value: config('emszmalapi.bank_credentials.'.$identifier.'.token_value') ?? ''
+                    provider: (int) config('emszmalapi.bank_credentials.'.$identifier.'.provider', 0),
+                    login: (string) config('emszmalapi.bank_credentials.'.$identifier.'.login', ''),
+                    password: (string) config('emszmalapi.bank_credentials.'.$identifier.'.password', ''),
+                    user_context: (string) config('emszmalapi.bank_credentials.'.$identifier.'.user_context', ''),
+                    token_value: (string) config('emszmalapi.bank_credentials.'.$identifier.'.token_value', '')
                 );
             });
 

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace KDuma\emSzmalAPI\Laravel;
 
-use Exception;
 use KDuma\emSzmalAPI\emSzmalAPI;
 use KDuma\emSzmalAPI\DTO\BankCredentials;
 use Illuminate\Contracts\Foundation\Application;
@@ -50,35 +49,37 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
             );
 
             $api->setDefaultBankCredentialsResolver(function ($identifier = 'default') {
-                if (! config('emszmalapi.bank_credentials.'.$identifier)) {
-                    throw new Exception('There is no credentials with id '.$identifier.'!');
-                }
-
                 $prefix = 'emszmalapi.bank_credentials.'.$identifier;
 
-                $provider = config($prefix.'.provider');
-                if (! is_int($provider) || $provider <= 0) {
+                if (! config($prefix)) {
                     throw new \RuntimeException(
-                        'emSzmal API: bank credentials "'.$identifier.'.provider" must be a positive integer.'
+                        'emSzmal API: '.$prefix.' is not configured.'
+                    );
+                }
+
+                $provider = config($prefix.'.provider');
+                if (! is_numeric($provider) || (int) $provider <= 0) {
+                    throw new \RuntimeException(
+                        'emSzmal API: '.$prefix.'.provider must be a positive integer.'
                     );
                 }
 
                 $login = config($prefix.'.login');
                 if (! is_string($login) || trim($login) === '') {
                     throw new \RuntimeException(
-                        'emSzmal API: bank credentials "'.$identifier.'.login" must be a non-empty string.'
+                        'emSzmal API: '.$prefix.'.login must be a non-empty string.'
                     );
                 }
 
                 $password = config($prefix.'.password');
                 if (! is_string($password) || trim($password) === '') {
                     throw new \RuntimeException(
-                        'emSzmal API: bank credentials "'.$identifier.'.password" must be a non-empty string.'
+                        'emSzmal API: '.$prefix.'.password must be a non-empty string.'
                     );
                 }
 
                 return new BankCredentials(
-                    provider: $provider,
+                    provider: (int) $provider,
                     login: $login,
                     password: $password,
                     user_context: (string) config($prefix.'.user_context', ''),

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -41,24 +41,32 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
                 throw new \RuntimeException('emSzmal API: emszmalapi.license.api_key must be a non-empty string.');
             }
 
+            $timeout = config('emszmalapi.timeout', 120);
+            if (filter_var($timeout, FILTER_VALIDATE_INT) === false || (int) $timeout <= 0) {
+                throw new \RuntimeException(
+                    'emSzmal API: emszmalapi.timeout must be a positive integer.'
+                );
+            }
+
             $api = new emSzmalAPI(
                 api_id: $apiId,
                 api_key: $apiKey,
-                timeout: (int) config('emszmalapi.timeout', 120),
+                timeout: (int) $timeout,
                 cache_provider: $app->make(CacheProviderInterface::class),
             );
 
             $api->setDefaultBankCredentialsResolver(function ($identifier = 'default') {
                 $prefix = 'emszmalapi.bank_credentials.'.$identifier;
 
-                if (! config($prefix)) {
+                $credentials = config($prefix);
+                if (! is_array($credentials) || empty($credentials)) {
                     throw new \RuntimeException(
                         'emSzmal API: '.$prefix.' is not configured.'
                     );
                 }
 
                 $provider = config($prefix.'.provider');
-                if (! is_numeric($provider) || (int) $provider <= 0) {
+                if (filter_var($provider, FILTER_VALIDATE_INT) === false || (int) $provider <= 0) {
                     throw new \RuntimeException(
                         'emSzmal API: '.$prefix.'.provider must be a positive integer.'
                     );

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -34,12 +34,12 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
             $apiId = config('emszmalapi.license.api_id');
             $apiKey = config('emszmalapi.license.api_key');
 
-            if (empty($apiId) || ! is_string($apiId)) {
-                throw new \RuntimeException('emSzmal API: emszmalapi.license.api_id is not configured.');
+            if (! is_string($apiId) || trim($apiId) === '') {
+                throw new \RuntimeException('emSzmal API: emszmalapi.license.api_id must be a non-empty string.');
             }
 
-            if (empty($apiKey) || ! is_string($apiKey)) {
-                throw new \RuntimeException('emSzmal API: emszmalapi.license.api_key is not configured.');
+            if (! is_string($apiKey) || trim($apiKey) === '') {
+                throw new \RuntimeException('emSzmal API: emszmalapi.license.api_key must be a non-empty string.');
             }
 
             $api = new emSzmalAPI(
@@ -54,12 +54,35 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
                     throw new Exception('There is no credentials with id '.$identifier.'!');
                 }
 
+                $prefix = 'emszmalapi.bank_credentials.'.$identifier;
+
+                $provider = config($prefix.'.provider');
+                if (! is_int($provider) || $provider <= 0) {
+                    throw new \RuntimeException(
+                        'emSzmal API: bank credentials "'.$identifier.'.provider" must be a positive integer.'
+                    );
+                }
+
+                $login = config($prefix.'.login');
+                if (! is_string($login) || trim($login) === '') {
+                    throw new \RuntimeException(
+                        'emSzmal API: bank credentials "'.$identifier.'.login" must be a non-empty string.'
+                    );
+                }
+
+                $password = config($prefix.'.password');
+                if (! is_string($password) || trim($password) === '') {
+                    throw new \RuntimeException(
+                        'emSzmal API: bank credentials "'.$identifier.'.password" must be a non-empty string.'
+                    );
+                }
+
                 return new BankCredentials(
-                    provider: (int) config('emszmalapi.bank_credentials.'.$identifier.'.provider', 0),
-                    login: (string) config('emszmalapi.bank_credentials.'.$identifier.'.login', ''),
-                    password: (string) config('emszmalapi.bank_credentials.'.$identifier.'.password', ''),
-                    user_context: (string) config('emszmalapi.bank_credentials.'.$identifier.'.user_context', ''),
-                    token_value: (string) config('emszmalapi.bank_credentials.'.$identifier.'.token_value', '')
+                    provider: $provider,
+                    login: $login,
+                    password: $password,
+                    user_context: (string) config($prefix.'.user_context', ''),
+                    token_value: (string) config($prefix.'.token_value', '')
                 );
             });
 

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -6,6 +6,7 @@ namespace KDuma\emSzmalAPI\Laravel;
 
 use KDuma\emSzmalAPI\emSzmalAPI;
 use KDuma\emSzmalAPI\DTO\BankCredentials;
+use KDuma\emSzmalAPI\Enums\Bank;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use KDuma\emSzmalAPI\CacheProviders\LaravelCacheProvider;
@@ -42,7 +43,10 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
             }
 
             $timeout = config('emszmalapi.timeout', 120);
-            if (filter_var($timeout, FILTER_VALIDATE_INT) === false || (int) $timeout <= 0) {
+            if ((! is_int($timeout) && ! is_string($timeout))
+                || filter_var($timeout, FILTER_VALIDATE_INT) === false
+                || (int) $timeout <= 0
+            ) {
                 throw new \RuntimeException(
                     'emSzmal API: emszmalapi.timeout must be a positive integer.'
                 );
@@ -66,9 +70,16 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
                 }
 
                 $provider = config($prefix.'.provider');
-                if (filter_var($provider, FILTER_VALIDATE_INT) === false || (int) $provider <= 0) {
+                if ($provider instanceof Bank) {
+                    $providerId = $provider->value;
+                } elseif ((is_int($provider) || is_string($provider))
+                    && filter_var($provider, FILTER_VALIDATE_INT) !== false
+                    && (int) $provider > 0
+                ) {
+                    $providerId = (int) $provider;
+                } else {
                     throw new \RuntimeException(
-                        'emSzmal API: '.$prefix.'.provider must be a positive integer.'
+                        'emSzmal API: '.$prefix.'.provider must be a positive integer or a Bank enum value.'
                     );
                 }
 
@@ -87,11 +98,11 @@ class ServiceProvider extends LaravelServiceProvider implements DeferrableProvid
                 }
 
                 return new BankCredentials(
-                    provider: (int) $provider,
+                    provider: $providerId,
                     login: $login,
                     password: $password,
                     user_context: (string) config($prefix.'.user_context', ''),
-                    token_value: (string) config($prefix.'.token_value', '')
+                    token_value: (string) config($prefix.'.token_value', ''),
                 );
             });
 


### PR DESCRIPTION
- Validate api_id and api_key are non-empty strings, throwing RuntimeException with a clear message if missing
- Cast timeout to (int) to avoid strict_types TypeError
- Cast provider to (int) and use default 0 instead of '' to satisfy int|Bank type constraint on BankCredentials constructor
- Cast login/password/user_context/token_value to (string) explicitly